### PR TITLE
Enable tls and improve config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,10 @@ You need to have OpenCL installed. To download and build gominer, run:
 
 ## Running
 
-No TLS support yet, sorry!
-
 Run for benchmark:
 
     gominer -B
 
 Run for real mining:
 
-    gominer -u myusername -P hunter2 -c http://localhost:9109
+    gominer -u myusername -P hunter2

--- a/sample-gominer.conf
+++ b/sample-gominer.conf
@@ -1,0 +1,35 @@
+[Application Options]
+
+; ------------------------------------------------------------------------------
+; Network settings
+; ------------------------------------------------------------------------------
+
+; Use testnet (cannot be used with simnet=1).
+; testnet=1
+
+; Use simnet (cannot be used with testnet=1).
+; simnet=1
+
+
+; ------------------------------------------------------------------------------
+; RPC client settings
+; ------------------------------------------------------------------------------
+
+; Connect via a SOCKS5 proxy.
+; proxy=127.0.0.1:9050
+; proxyuser=
+; proxypass=
+
+; Username and password to authenticate connections to a Decred RPC server
+; (usually dcrd)
+; rpcuser=
+; rpcpass=
+
+; RPC server to connect to
+; rpcserver=localhost
+
+; RPC server certificate chain file for validation
+; rpccert=~/.dcrd/rpc.cert
+
+; Disable tls for rpc
+; notls=1


### PR DESCRIPTION
Config changed to match dcrctl since that is closer to what the miner
does.  This removed some totally unneeded options and changed some
others.

gominer now uses its own directory for config rather than reusing the
dcrd one.

Add back btc/dcr copyright in config.go (since the whole file came
from there).

Add sample config file.