### PR TITLE
Reconnect to pool if no usable target is provided.

### DIFF
--- a/stratum.go
+++ b/stratum.go
@@ -863,6 +863,19 @@ func (s *Stratum) PrepWork() error {
 		workData[128+4*timestampWord : 132+4*timestampWord])
 	atomic.StoreUint32(&s.latestJobTime, givenTs)
 
+	if s.Target == nil {
+		poolLog.Errorf("No target set!  Reconnecting to pool.")
+		err = s.Reconnect()
+		if err != nil {
+			poolLog.Error(err)
+			// XXX should just die at this point
+			// but we don't really have access to
+			// the channel to end everything.
+			return err
+		}
+		return nil
+	}
+
 	w := NewWork(workData, s.Target, givenTs, uint32(time.Now().Unix()), false)
 
 	poolLog.Tracef("Stratum prepated work data %v, target %032x",


### PR DESCRIPTION
If a target that we cannot use (<1 for example) is set
do not attempt to do work without the target (which would panic).

Instead, reconnect to pool which gets back the pool's default target.

Closes #41.