### PR TITLE
Fix benchmark mode.

### DIFF
--- a/device.go
+++ b/device.go
@@ -479,15 +479,17 @@ func (d *Device) foundCandidate(ts, nonce0, nonce1 uint32) {
 		d.allDiffOneShares++
 	}
 
-	// Assess versus the pool or daemon target.
-	if hashNum.Cmp(d.work.Target) > 0 {
-		minrLog.Debugf("GPU #%d: Hash %v bigger than target %032x (boo)",
-			d.index, hash, d.work.Target.Bytes())
-	} else {
-		minrLog.Infof("GPU #%d: Found hash with work below target! %v (yay)",
-			d.index, hash)
-		d.validShares++
-		d.workDone <- data
+	if !cfg.Benchmark {
+		// Assess versus the pool or daemon target.
+		if hashNum.Cmp(d.work.Target) > 0 {
+			minrLog.Debugf("GPU #%d: Hash %v bigger than target %032x (boo)",
+				d.index, hash, d.work.Target.Bytes())
+		} else {
+			minrLog.Infof("GPU #%d: Found hash with work below target! %v (yay)",
+				d.index, hash)
+			d.validShares++
+			d.workDone <- data
+		}
 	}
 }
 

--- a/miner.go
+++ b/miner.go
@@ -239,16 +239,18 @@ func (m *Miner) printStatsThread() {
 	defer t.Stop()
 
 	for {
-		valid := atomic.LoadUint64(&m.validShares)
-		minrLog.Infof("Global stats: Accepted: %v, Rejected: %v, Stale: %v",
-			valid,
-			atomic.LoadUint64(&m.invalidShares),
-			atomic.LoadUint64(&m.staleShares))
+		if !cfg.Benchmark {
+			valid := atomic.LoadUint64(&m.validShares)
+			minrLog.Infof("Global stats: Accepted: %v, Rejected: %v, Stale: %v",
+				valid,
+				atomic.LoadUint64(&m.invalidShares),
+				atomic.LoadUint64(&m.staleShares))
 
-		secondsElapsed := uint32(time.Now().Unix()) - m.started
-		if (secondsElapsed / 60) > 0 {
-			utility := float64(valid) / (float64(secondsElapsed) / float64(60))
-			minrLog.Infof("Global utility (accepted shares/min): %v", utility)
+			secondsElapsed := uint32(time.Now().Unix()) - m.started
+			if (secondsElapsed / 60) > 0 {
+				utility := float64(valid) / (float64(secondsElapsed) / float64(60))
+				minrLog.Infof("Global utility (accepted shares/min): %v", utility)
+			}
 		}
 		for _, d := range m.devices {
 			d.PrintStats()


### PR DESCRIPTION
This prevents a panic when comparing against the non-existant
target in benchmark mode.

Also supress output related to shares in benchmark mode.

Fixes #45