### PR TITLE
Fix check for userSetWorkSize

### DIFF
--- a/miner.go
+++ b/miner.go
@@ -86,7 +86,7 @@ func NewMiner() (*Miner, error) {
 	}
 
 	// Check the number of intensities/work sizes versus the number of devices.
-	userSetWorkSize := false
+	userSetWorkSize := true
 	if reflect.DeepEqual(cfg.Intensity, defaultIntensity) &&
 		reflect.DeepEqual(cfg.WorkSize, defaultWorkSize) {
 		userSetWorkSize = false


### PR DESCRIPTION
The check for userSetWorkSize in miner.go was broken, causing the check for number if input intensities and worksizes to fail to detect a mismatch, which causes a crash when specifying only one worksize/intensity on a dual gpu system.