### PR TITLE
Fix the size of data copied from device.

### DIFF
--- a/cudevice.go
+++ b/cudevice.go
@@ -253,7 +253,7 @@ func (d *Device) runCuDevice() error {
 
 		decredHashNonce(gridx, blockx, throughput, startNonce, nonceResultsD, targetHigh)
 
-		cu.MemcpyDtoH(nonceResultsH, nonceResultsD, d.cuInSize*4)
+		cu.MemcpyDtoH(nonceResultsH, nonceResultsD, d.cuInSize)
 
 		numResults := nonceResultsHSlice[0]
 		for i, result := range nonceResultsHSlice[1 : 1+numResults] {


### PR DESCRIPTION
This seems to have a slight performance bonus.

On GeForce GTX 970 goes from 1.528GH/s to 1.576GH/s.

Closes #98.