### PR TITLE
Improve cpu usage with CUDA.

### DIFF
--- a/README.windows
+++ b/README.windows
@@ -29,7 +29,7 @@ Compiling gominer on windows requires installation in following order:
 * ensure that GOPATH is set somewhere sane (e.g. %HOMEPATH%\go)
 
 Install mumax/3 (in cmd.exe):
-$ go get github.com/mumax/3
+$ go get github.com/jcvernaleo/3
 
 Install glide (in git-bash):
 $ go get github.com/Masterminds/glide

--- a/cudakernel_static.go
+++ b/cudakernel_static.go
@@ -9,7 +9,7 @@ package main
 */
 import "C"
 import (
-	"github.com/mumax/3/cuda/cu"
+	"github.com/jcvernaleo/3/cuda/cu"
 	"unsafe"
 )
 

--- a/cudakernel_windows.go
+++ b/cudakernel_windows.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/mumax/3/cuda/cu"
+	"github.com/jcvernaleo/3/cuda/cu"
 )
 
 var (

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 91c7f7aacbc4b5f82b14c9de3212c07257421b40c37926f571c3bc79f19c6060
-updated: 2016-08-16T11:10:41.055231248-04:00
+hash: a629ff7ac31d9554df88c93ed389d830fda2bb73a5d2c53b73d362dac0538e93
+updated: 2016-09-28T11:19:49.975498348-04:00
 imports:
 - name: github.com/btcsuite/btclog
   version: f96df2375f37300305f329b8e5258764b4f19a7f
@@ -45,8 +45,8 @@ imports:
   version: b0909d3f798b97a03c9e77023f97a5301a2a7900
   subpackages:
   - edwards25519
-- name: github.com/mumax/3
-  version: 9859625390900fa7029ce8cfdeb430f239e502d4
+- name: github.com/jcvernaleo/3
+  version: ff7ea4431a97bb2b389739cb9087bbc11faa1fe0
   subpackages:
   - cuda/cu
 - name: golang.org/x/sys

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,3 +16,6 @@ import:
   - chaincfg/chainhash
   - wire
 - package: github.com/decred/dcrutil
+- package: github.com/jcvernaleo/3
+  subpackages:
+  - cuda/cu


### PR DESCRIPTION
Switch to fork of mumax/3/cuda/cu that adds calls to the CUDA runtime
api.  ccminer uses the runtime api and so by using that we can use the
same methods to get similar cpu performance.

This also removes the use of CUDA contexts complete.

There are still a few calls (for getting device count, version, etc)
that use the older driver api but you are allowed to mix and match and
those can be converted at a later date if desired.

Closes #86