### PR TITLE
Updates to goclean.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ before_install:
 install:
   - go get -v github.com/Masterminds/glide
   - glide install
-  - go get -v golang.org/x/tools/cmd/cover
-  - go get -v github.com/bradfitz/goimports
-  - go get -v github.com/golang/lint/golint
-  - go get -v github.com/davecgh/go-spew/spew
+  - go get -v github.com/alecthomas/gometalinter
+  - gometalinter --install
 script:
   - export PATH=$PATH:$HOME/gopath/bin
   - ./goclean.sh

--- a/cudakernel_static.go
+++ b/cudakernel_static.go
@@ -9,8 +9,9 @@ package main
 */
 import "C"
 import (
-	"github.com/jcvernaleo/3/cuda/cu"
 	"unsafe"
+
+	"github.com/jcvernaleo/3/cuda/cu"
 )
 
 func cudaPrecomputeTable(input *[192]byte) {

--- a/goclean.sh
+++ b/goclean.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 # The script does automatic checking on a Go package and its sub-packages, including:
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
-# 2. golint        (https://github.com/golang/lint)
-# 3. go vet        (http://golang.org/cmd/vet)
-# 4. race detector (http://blog.golang.org/race-detector)
-# 5. test coverage (http://blog.golang.org/cover)
+# 2. go vet        (http://golang.org/cmd/vet)
+# 3. goimports     (https://github.com/bradfitz/goimports)
+
+# gometalinter (github.com/alecthomas/gometalinter) is used to run each each
+# static checker.
 
 set -ex
 
 # Automatic checks
+test -z "$(gometalinter --disable-all \
+--enable=gofmt \
+--enable=vet \
+--enable=goimports \
+--deadline=45s $(glide novendor) | tee /dev/stderr)"
 test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
-# TODO
-#test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_\|NewFieldVal' | tee /dev/stderr)"
 test -z "$(go vet $(glide novendor) 2>&1 | tee /dev/stderr)"
-# TODO
-#env GORACE="halt_on_error=1" go test -v -race $(glide novendor)
+


### PR DESCRIPTION
Switch to use gometalinter like the other projects.

Only list static checkers we actually use.

Fix ordering of imports caught by goimports.

Closes #128