### PR TITLE
Add check on json to prevent panic.

### DIFF
--- a/stratum/stratum.go
+++ b/stratum/stratum.go
@@ -578,6 +578,10 @@ func (s *Stratum) Unmarshal(blob []byte) (interface{}, error) {
 			return nil, err
 		}
 
+		if len(resJS) == 0 {
+			return nil, errJsonType
+		}
+
 		var msgPeak []interface{}
 		err = json.Unmarshal(resJS[0], &msgPeak)
 		if err != nil {


### PR DESCRIPTION
make sure the unmarshaled json is not zero length so we don't panic
when trying to read it.

Along with #141 
Closes #135 