### PR TITLE
fix quit hang, other tweaks

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-CC ?= gcc -fPIC
+CC ?= gcc -fPIC -march=native -O3
 CXX ?= g++ -fPIC
 NVCC ?= nvcc -Xcompiler -fPIC
 AR ?= ar

--- a/cudevice.go
+++ b/cudevice.go
@@ -185,7 +185,7 @@ func ListDevices() {
 	// Because mumux3/3/cuda/cu likes to panic instead of error.
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Println("No CUDA Capable GPUs present")
+			fmt.Println("No CUDA Capable GPUs present", r)
 		}
 	}()
 	devices, _ := getCUDevices()
@@ -194,8 +194,7 @@ func ListDevices() {
 	}
 }
 
-func NewCuDevice(index int, order int, deviceID cu.Device,
-	workDone chan []byte) (*Device, error) {
+func NewCuDevice(index int, order int, deviceID cu.Device, workDone chan []byte) (*Device, error) {
 
 	d := &Device{
 		index:       index,
@@ -308,12 +307,6 @@ func (d *Device) runDevice() error {
 	for {
 		d.updateCurrentWork()
 
-		select {
-		case <-d.quit:
-			return nil
-		default:
-		}
-
 		// Increment extraNonce.
 		util.RolloverExtraNonce(&d.extraNonce)
 		d.lastBlock[work.Nonce1Word] = util.Uint32EndiannessSwap(d.extraNonce)
@@ -382,11 +375,10 @@ func (d *Device) runDevice() error {
 }
 
 func minUint32(a, b uint32) uint32 {
-	if a > b {
+	if a < b {
 		return a
-	} else {
-		return b
 	}
+	return b
 }
 
 func newMinerDevs(m *Miner) (*Miner, int, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/gominer
 
+go 1.15
+
 require (
 	github.com/barnex/cuda5 v0.0.0-20171012184954-da30a9b287d8
 	github.com/davecgh/go-spew v1.1.1
@@ -13,5 +15,3 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
 )
-
-go 1.12


### PR DESCRIPTION
Quitting gominer would pretty much always hang.

This PR includes the quit fix and other fixes from a different work branch that includes a hack to mine a block every 120 second (just pause after getting a result and before going on to new work).  For anyone interested, I use this to keep testnet going with no continuous resource use, just a few ms of compute every couple minutes  https://github.com/chappjc/gominer/commit/6744bc2206380ddbb165233edae9601b83170126