### PR TITLE
Correct several stratum/pooled mining issues.

### DIFF
--- a/cladldevice.go
+++ b/cladldevice.go
@@ -497,13 +497,9 @@ func (d *Device) runDevice() error {
 		util.RolloverExtraNonce(&d.extraNonce2)
 		d.lastBlock[work.Nonce2Word] = d.extraNonce2
 
-		// Update the timestamp. Only solo work allows you to roll
-		// the timestamp.
-		ts := d.work.JobTime
-		if d.work.IsGetWork {
-			diffSeconds := uint32(time.Now().Unix()) - d.work.TimeReceived
-			ts = d.work.JobTime + diffSeconds
-		}
+		// Update the timestamp.
+		diffSeconds := uint32(time.Now().Unix()) - d.work.TimeReceived
+		ts += d.work.JobTime + diffSeconds
 		d.lastBlock[work.TimestampWord] = ts
 
 		// arg 0: pointer to the buffer

--- a/cldevice.go
+++ b/cldevice.go
@@ -624,13 +624,9 @@ func (d *Device) runDevice(ctx context.Context) error {
 		util.RolloverExtraNonce(&d.extraNonce2)
 		d.lastBlock[work.Nonce2Word] = d.extraNonce2
 
-		// Update the timestamp. Only solo work allows you to roll
-		// the timestamp.
-		ts := d.work.JobTime
-		if d.work.IsGetWork {
-			diffSeconds := uint32(time.Now().Unix()) - d.work.TimeReceived
-			ts = d.work.JobTime + diffSeconds
-		}
+		// Update the timestamp.
+		diffSeconds := uint32(time.Now().Unix()) - d.work.TimeReceived
+		ts := d.work.JobTime + diffSeconds
 		d.lastBlock[work.TimestampWord] = ts
 
 		// arg 0: pointer to the buffer

--- a/cudevice.go
+++ b/cudevice.go
@@ -394,13 +394,9 @@ func (d *Device) runDevice(ctx context.Context) error {
 		util.RolloverExtraNonce(&d.extraNonce2)
 		d.lastBlock[work.Nonce2Word] = d.extraNonce2
 
-		// Update the timestamp. Only solo work allows you to roll
-		// the timestamp.
-		ts := d.work.JobTime
-		if d.work.IsGetWork {
-			diffSeconds := uint32(time.Now().Unix()) - d.work.TimeReceived
-			ts = d.work.JobTime + diffSeconds
-		}
+		// Update the timestamp.
+		diffSeconds := uint32(time.Now().Unix()) - d.work.TimeReceived
+		ts := d.work.JobTime + diffSeconds
 		d.lastBlock[work.TimestampWord] = ts
 
 		// Clear the results buffer.

--- a/miner.go
+++ b/miner.go
@@ -38,7 +38,8 @@ func NewMiner() (*Miner, error) {
 
 	// If needed, start pool code.
 	if cfg.Pool != "" && !cfg.Benchmark {
-		s, err := stratum.StratumConn(cfg.Pool, cfg.PoolUser, cfg.PoolPassword, cfg.Proxy, cfg.ProxyUser, cfg.ProxyPass, version())
+		s, err := stratum.StratumConn(cfg.Pool, cfg.PoolUser, cfg.PoolPassword,
+			cfg.Proxy, cfg.ProxyUser, cfg.ProxyPass, version(), chainParams)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This updates the code to properly support pooled mining via stratum.

In particular:

- The extra nonce provided by the pool is now correctly set and used
- The length for the second extra nonce provided by the pool is now validated
- The second extra nonce length now respects the provided length
- The mining code now uses the correct offset within the serialized work data for the second extra nonce to ensure the pool properly reconstructs the header
- The provided timestamp is now updated locally as the mining process is underway and the final timestamp is submitted along with the share as expected
- The correct network parameters for the active network are now passed into the stratum code so the right difficulties are used
- The stratum fields that represent numbers are now consistently in little endian per the stratum "spec" (such that it is)
- The "second generation tx" field is now ignored because it does not apply to Decred

Finally, various loggging messages have been cleaned up and the job id is no longer incorrectly expected to be numeric when logging it.