### PR TITLE
version: Support single override and add git hash.

### DIFF
--- a/config.go
+++ b/config.go
@@ -318,7 +318,8 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	if preCfg.ShowVersion {
-		fmt.Printf("%s %s version %s (Go version %s)\n", appName, gpuLib(), version(), runtime.Version())
+		fmt.Printf("%s %s version %s (Go version %s %s/%s)\n", appName, gpuLib(),
+			Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ func gominerMain() error {
 	}()
 
 	// Show version at startup.
-	mainLog.Infof("Version %s %s (Go version %s)",
-		version(), gpuLib(), runtime.Version())
+	mainLog.Infof("Version %s %s (Go version %s %s/%s)", Version, gpuLib(),
+		runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
 	// Enable http profiling server if requested.
 	if cfg.Profile != "" {

--- a/miner.go
+++ b/miner.go
@@ -39,7 +39,8 @@ type Miner struct {
 }
 
 func newStratum(devices []*Device) (*Miner, error) {
-	s, err := stratum.StratumConn(cfg.Pool, cfg.PoolUser, cfg.PoolPassword, cfg.Proxy, cfg.ProxyUser, cfg.ProxyPass, version(), chainParams)
+	s, err := stratum.StratumConn(cfg.Pool, cfg.PoolUser, cfg.PoolPassword,
+		cfg.Proxy, cfg.ProxyUser, cfg.ProxyPass, Version, chainParams)
 	if err != nil {
 		return nil, err
 	}

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013, 2014 The btcsuite developers
- * Copyright (c) 2015 The Decred developers
+ * Copyright (c) 2015-2023 The Decred developers
  * Copyright (c) 2016 Dario Nieuwenhuis
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -19,72 +19,169 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
+	"regexp"
+	"runtime/debug"
+	"strconv"
 	"strings"
 )
 
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
-
-// These constants define the application version and follow the semantic
-// versioning 2.0.0 spec (http://semver.org/).
 const (
-	appMajor uint = 1
-	appMinor uint = 0
-	appPatch uint = 0
-
-	// appPreRelease MUST only contain characters from semanticAlphabet
-	// per the semantic versioning spec.
-	appPreRelease = "beta"
+	// semanticAlphabet defines the allowed characters for the pre-release and
+	// build metadata portions of a semantic version string.
+	semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 )
 
-// appBuild is defined as a variable so it can be overridden during the build
-// process with '-ldflags "-X main.appBuild=foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
-var appBuild = "dev"
+// semverRE is a regular expression used to parse a semantic version string into
+// its constituent parts.
+var semverRE = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*` +
+	`[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
-// version returns the application version as a properly formed string per the
-// semantic versioning 2.0.0 spec (http://semver.org/).
-func version() string {
-	// Start with the major, minor, and path versions.
-	version := fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
+// These variables define the application version and follow the semantic
+// versioning 2.0.0 spec (https://semver.org/).
+var (
+	// Note for maintainers:
+	//
+	// The expected process for setting the version in releases is as follows:
+	// - Create a release branch of the form 'release-vMAJOR.MINOR'
+	// - Modify the Version variable below on that branch to:
+	//   - Remove the pre-release portion
+	//   - Set the build metadata to 'release.local'
+	// - Update the Version variable below on the master branch to the next
+	//   expected version while retaining a pre-release of 'pre'
+	//
+	// These steps ensure that building from source produces versions that are
+	// distinct from reproducible builds that override the Version via linker
+	// flags.
 
-	// Append pre-release version if there is one.  The hyphen called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the pre-release string.  The pre-release version
-	// is not appended if it contains invalid characters.
-	preRelease := normalizeVerString(appPreRelease)
-	if preRelease != "" {
-		version = fmt.Sprintf("%s-%s", version, preRelease)
+	// Version is the application version per the semantic versioning 2.0.0 spec
+	// (https://semver.org/).
+	//
+	// It is defined as a variable so it can be overridden during the build
+	// process with:
+	// '-ldflags "-X main.Version=fullsemver"'
+	// if needed.
+	//
+	// It MUST be a full semantic version per the semantic versioning spec or
+	// the app will panic at runtime.  Of particular note is the pre-release
+	// and build metadata portions MUST only contain characters from
+	// semanticAlphabet.
+	Version = "2.0.0-pre"
+
+	// NOTE: The following values are set via init by parsing the above Version
+	// string.
+
+	// These fields are the individual semantic version components that define
+	// the application version.
+	Major         uint32
+	Minor         uint32
+	Patch         uint32
+	PreRelease    string
+	BuildMetadata string
+)
+
+// parseUint32 converts the passed string to an unsigned integer or returns an
+// error if it is invalid.
+func parseUint32(s string, fieldName string) (uint32, error) {
+	val, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("malformed semver %s: %w", fieldName, err)
 	}
-
-	// Append build metadata if there is any.  The plus called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the build metadata string.  The build metadata
-	// string is not appended if it contains invalid characters.
-	build := normalizeVerString(appBuild)
-	if build != "" {
-		version = fmt.Sprintf("%s+%s", version, build)
-	}
-
-	return version
+	return uint32(val), err
 }
 
-// normalizeVerString returns the passed string stripped of all characters which
-// are not valid according to the semantic versioning guidelines for pre-release
-// version and build metadata strings.  In particular they MUST only contain
-// characters in semanticAlphabet.
-func normalizeVerString(str string) string {
-	result := bytes.Buffer{}
-	for _, r := range str {
-		if strings.ContainsRune(semanticAlphabet, r) {
-			_, err := result.WriteRune(r)
-			// Writing to a bytes.Buffer panics on OOM, and all
-			// errors are unexpected.
-			if err != nil {
-				panic(err)
-			}
+// checkSemString returns an error if the passed string contains characters that
+// are not in the provided alphabet.
+func checkSemString(s, alphabet, fieldName string) error {
+	for _, r := range s {
+		if !strings.ContainsRune(alphabet, r) {
+			return fmt.Errorf("malformed semver %s: %q invalid", fieldName, r)
 		}
 	}
-	return result.String()
+	return nil
+}
+
+// parseSemVer parses various semver components from the provided string.
+func parseSemVer(s string) (uint32, uint32, uint32, string, string, error) {
+	// Parse the various semver component from the version string via a regular
+	// expression.
+	m := semverRE.FindStringSubmatch(s)
+	if m == nil {
+		err := fmt.Errorf("malformed version string %q: does not conform to "+
+			"semver specification", s)
+		return 0, 0, 0, "", "", err
+	}
+
+	major, err := parseUint32(m[1], "major")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	minor, err := parseUint32(m[2], "minor")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	patch, err := parseUint32(m[3], "patch")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	preRel := m[4]
+	err = checkSemString(preRel, semanticAlphabet, "pre-release")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	build := m[5]
+	err = checkSemString(build, semanticAlphabet, "buildmetadata")
+	if err != nil {
+		return 0, 0, 0, "", "", err
+	}
+
+	return major, minor, patch, preRel, build, nil
+}
+
+// vcsCommitID attempts to return the version control system short commit hash
+// that was used to build the binary.  It currently only detects git commits.
+func vcsCommitID() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	var vcs, revision string
+	for _, bs := range bi.Settings {
+		switch bs.Key {
+		case "vcs":
+			vcs = bs.Value
+		case "vcs.revision":
+			revision = bs.Value
+		}
+	}
+	if vcs == "" {
+		return ""
+	}
+	if vcs == "git" && len(revision) > 9 {
+		revision = revision[:9]
+	}
+	return revision
+}
+
+func init() {
+	var err error
+	Major, Minor, Patch, PreRelease, BuildMetadata, err = parseSemVer(Version)
+	if err != nil {
+		panic(err)
+	}
+	if BuildMetadata == "" {
+		BuildMetadata = vcsCommitID()
+		if BuildMetadata != "" {
+			Version = fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
+			if PreRelease != "" {
+				Version += "-" + PreRelease
+			}
+			Version += "+" + BuildMetadata
+		}
+	}
 }


### PR DESCRIPTION
**This is rebased on #208**.

This reworks the way versions are handled internally to match other Decred software.

In particular, it reverses the semantics such that the individual semver components (major, minor, patch, prerelease, and buildmetadata) are parsed from a full string and exported at init time.

Also, since the version is now parsed and verified to be accurate, it updates the pre-release parsing to properly support dots as required by the spec.

It adds the git commit hash to the version string as buildmetadata when no buildmetadata is otherwise specified.

This provides a few main benefits:

- Allows a single linker override to fully specify the version string instead of having separate ones that can only override the prerelease and build metadata portions
- Provides run-time checks to ensure the full version string is valid per the semver spec regardless of whether it was specified directly in the source or provided via the linker
- The exact commit used to build non-release versions will be in the version string by default

Finally, while here, add some comments regarding the release process to help maintainers.